### PR TITLE
add ignoreLoadingBar flag

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -1,4 +1,3 @@
-
 /*
  * angular-loading-bar
  *
@@ -79,11 +78,13 @@ angular.module('chieffancypants.loadingBar', [])
 
       return {
         'request': function(config) {
-          if (!isCached(config)) {
-            if (reqsTotal === 0) {
-              cfpLoadingBar.start();
-            }
-            reqsTotal++;
+          if (!config.ignoreLoadingBar) {
+            if (!isCached(config)) {
+              if (reqsTotal === 0) {
+                cfpLoadingBar.start();
+              }
+              reqsTotal++;
+            } 
           }
           return config;
         },


### PR DESCRIPTION
I needed this feature for my production app when sending logging info I didn't want to spam the user with loading bars

example:

``` javascript
$http.post('/api/log/', data, {
  cache: false,
  ignoreLoadingBar: true
});
```
