### PR TITLE
added event hooks so users can monitor when angular-loading-bar is react...

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -259,11 +259,11 @@ angular.module('chieffancypants.loadingBar', [])
       }
 
       function _loading(url) {
-         $rootScope.$broadcast('cfpLoadingBar:loading:' + url);
+         $rootScope.$broadcast('cfpLoadingBar:loading', url);
       }
 
       function _loaded(url) {
-         $rootScope.$broadcast('cfpLoadingBar:loaded:' + url);
+         $rootScope.$broadcast('cfpLoadingBar:loaded', url);
       }
 
       return {


### PR DESCRIPTION
Here's something I found useful. I use it to see when loading-bar starts showing progress for a specific request, so I can match loading icons for specific elements exactly with the loading bar.

I used it like this:

``` javascript
app.run(['$rootScope', function($rootScope) {
   $rootScope.$on('cfpLoadingBar:loading:/service/fetchEmployees', function() {
      // hide employee editing controls and show loading icon
   });

   $rootScope.$on('cfpLoadingBar:loaded:/service/fetchEmployees', function() {
     // hide loading icon and show employee editing controls
   });
}])
```

Opinion?
