### PR TITLE
Progression bar not calculated correctly for consecutive calls within the 500ms delay

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -90,6 +90,7 @@ angular.module('chieffancypants.loadingBar', [])
               cfpLoadingBar.start();
             }
             reqsTotal++;
+            cfpLoadingBar.set(reqsCompleted / reqsTotal);
           }
           return config;
         },


### PR DESCRIPTION
https://github.com/chieffancypants/angular-loading-bar/issues/29
