### PR TITLE
Re-wrote fancy blur effect CSS

### DIFF
--- a/example/app.css
+++ b/example/app.css
@@ -168,10 +168,13 @@ h4 span {
 #loading-bar .bar {
   background: #2c3e50;
 }
-#loading-bar .peg {
-  box-shadow: 0 0 10px #2c3e50, 0 0 5px #2c3e50;
-}
 #loading-bar-spinner .spinner-icon {
   border-top-color:  #2c3e50;
   border-left-color: #2c3e50;
+}
+#loading-bar .peg-arrow, #loading-bar .peg {
+  -moz-box-shadow: #2c3e50 1px 0 6px 1px;
+  -ms-box-shadow: #2c3e50 1px 0 6px 1px;
+  -webkit-box-shadow: #2c3e50 1px 0 6px 1px;
+  box-shadow: #2c3e50 1px 0 6px 1px;
 }

--- a/src/loading-bar.css
+++ b/src/loading-bar.css
@@ -41,16 +41,30 @@
 
 /* Fancy blur effect */
 #loading-bar .peg {
-  position: absolute;
+  opacity: .6;
+  width: 180px;
+  right: -80px;
+  clip: rect(-6px,90px,14px,-6px);
+}
+
+#loading-bar .peg-arrow {
+  opacity: .6;
+  width: 20px;
   right: 0;
-  border-right: 40px solid #29d;
-  border-top: 1px solid rgba(0, 0, 0, 0);
-  border-bottom: 1px solid rgba(0, 0, 0, 0);
-  -webkit-filter: drop-shadow(0px 0px 2px rgba(0,0,0,0.75));
-  -moz-filter: drop-shadow(0px 0px 2px rgba(0,0,0,0.75));
-  -ms-filter: drop-shadow(0px 0px 2px rgba(0,0,0,0.75));
-  -o-filter: drop-shadow(0px 0px 2px rgba(0,0,0,0.75));
-  filter: drop-shadow(0px 0px 2px rgba(0,0,0,0.75));
+  clip: rect(-6px,22px,14px,10px);
+}
+
+#loading-bar .peg-arrow, #loading-bar .peg {
+  position: absolute;
+  top: 0;
+  height: 2px;
+  -moz-box-shadow: #29d 1px 0 6px 1px;
+  -ms-box-shadow: #29d 1px 0 6px 1px;
+  -webkit-box-shadow: #29d 1px 0 6px 1px;
+  box-shadow: #29d 1px 0 6px 1px;
+  -moz-border-radius: 100%;
+  -webkit-border-radius: 100%;
+  border-radius: 100%;
 }
 
 #loading-bar-spinner {

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -162,7 +162,7 @@ angular.module('chieffancypants.loadingBar', [])
 
       var $parentSelector = this.parentSelector,
         $parent = $document.find($parentSelector),
-        loadingBarContainer = angular.element('<div id="loading-bar"><div class="bar"><div class="peg"></div></div></div>'),
+        loadingBarContainer = angular.element('<div id="loading-bar"><div class="bar"><div class="peg"></div><div class="peg-arrow"></div></div></div>'),
         loadingBar = loadingBarContainer.find('div').eq(0),
         spinner = angular.element('<div id="loading-bar-spinner"><div class="spinner-icon"></div></div>');
 


### PR DESCRIPTION
I used this loading bar in my application but ran into style issues when trying to move the loading bar below my navigation bar. 

I decided to imitate your original blur effect using a CSS triangle and a drop shadow. This removes the need to have the 'peg' sticking out at the top of the loading bar.

The colour of the triangle should match the colour of the loading bar.

```
border-right: 40px solid #29d;
```
