### PR TITLE
Fix when config is undefined.

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -115,7 +115,7 @@ angular.module('chieffancypants.loadingBar', [])
         },
 
         'response': function(response) {
-          if ('config' in response && !isCached(response.config)) {
+          if (response && 'config' in response && !isCached(response.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: response.config.url});
             if (reqsCompleted >= reqsTotal) {
@@ -128,7 +128,7 @@ angular.module('chieffancypants.loadingBar', [])
         },
 
         'responseError': function(rejection) {
-          if ('config' in rejection && !isCached(rejection.config)) {
+          if (rejection && 'config' in rejection && !isCached(rejection.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: rejection.config.url});
             if (reqsCompleted >= reqsTotal) {


### PR DESCRIPTION
Sometimes, the config is not provided in cache function. So, I fixed it.
# TypeError: Cannot read property 'config' of undefined
