### PR TITLE
Move angular-animate dependency out of 'dev' dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,10 +8,10 @@
     "components",
     "test",
     "example"
-  ],,
+  ],
   "dependencies": {
     "angular-animate": "~1.2.9"
-  }
+  },
   "devDependencies": {
     "angular-mocks": "~1.2.9"
   }


### PR DESCRIPTION
`angular-animate` is not only required in dev mode, surely?
Userland usage of this lib would require `angular-animate` I believe
