### PR TITLE
Loading-bar cover all tags

### DIFF
--- a/src/loading-bar.css
+++ b/src/loading-bar.css
@@ -32,7 +32,7 @@
 
   background: #29d;
   position: fixed;
-  z-index: 2000;
+  z-index: 10002;
   top: 0;
   left: 0;
   width: 100%;
@@ -61,7 +61,7 @@
 #loading-bar-spinner {
   display: block;
   position: fixed;
-  z-index: 2000;
+  z-index: 10002;
   top: 10px;
   left: 10px;
 }


### PR DESCRIPTION
Make loading bar overriding everything.
Such as some Bootstrap extensions like Metronic that I used make `.navbar {z-index: 9995}`, so I think `10002` may be a suitable number to cover most of tag.(`1000` or `10000` always suggested to solve z-index errors as I know)
