### PR TITLE
ignoreLoadingBar parameter not working on response

### DIFF
--- a/build/loading-bar.js
+++ b/build/loading-bar.js
@@ -117,7 +117,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         },
 
         'response': function(response) {
-          if (!response.config.ignoreLoadingBar && !isCached(response.config)) {
+          if (!isCached(response.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: response.config.url});
             if (reqsCompleted >= reqsTotal) {
@@ -130,7 +130,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         },
 
         'responseError': function(rejection) {
-          if (!rejection.config.ignoreLoadingBar && !isCached(rejection.config)) {
+          if (!isCached(rejection.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: rejection.config.url});
             if (reqsCompleted >= reqsTotal) {


### PR DESCRIPTION
I need to make multiple requests to a service (one every second) in order to get results. So I used the ignoreLoadingBar parameter for my $http requests and used the cfpLoadingBar.start() and cfpLoadingBar.complete() manually.

The problem is that only the request ignores the loading bar animation. Even if I pass the ignoreLoadingBar parameter, on response my manually triggered loading bar gets hidden.
