### PR TITLE
Use cache logic similar to angular core

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -67,19 +67,15 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
        */
       function isCached(config) {
         var cache;
+        var defaultCache = $cacheFactory.get('$http');
         var defaults = $httpProvider.defaults;
 
-        if (config.method !== 'GET' || config.cache === false) {
-          config.cached = false;
-          return false;
-        }
-
-        if (config.cache === true && defaults.cache === undefined) {
-          cache = $cacheFactory.get('$http');
-        } else if (defaults.cache !== undefined) {
-          cache = defaults.cache;
-        } else {
-          cache = config.cache;
+        // Choose the proper cache source. Borrowed from angular: $http service
+        if ((config.cache || defaults.cache) && config.cache !== false &&
+          (config.method === 'GET' || config.method === 'JSONP')) {
+            cache = angular.isObject(config.cache) ? config.cache
+              : angular.isObject(defaults.cache) ? defaults.cache
+              : defaultCache;
         }
 
         var cached = cache !== undefined ?

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -111,6 +111,30 @@ describe 'loadingBarInterceptor Service', ->
     $httpBackend.verifyNoOutstandingRequest()
     $timeout.flush() # loading bar is animated, so flush timeout
 
+  it 'should use default cache when $http.defaults.cache is true', inject (cfpLoadingBar, $cacheFactory) ->
+    # $http.defaults.cache = $cacheFactory('loading-bar')
+    $http.defaults.cache = true
+    $httpBackend.expectGET(endpoint).respond response
+    $http.get(endpoint).then (data) ->
+      result = data
+
+    expect(cfpLoadingBar.status()).toBe 0
+    $timeout.flush()
+    $timeout.flush()
+    $httpBackend.flush(1)
+    expect(cfpLoadingBar.status()).toBe 1
+    cfpLoadingBar.complete() # set as complete
+    $timeout.flush()
+    $animate.triggerCallbacks()
+
+
+    $http.get(endpoint).then (data) ->
+      result = data
+    # no need to flush $httpBackend since the response is cached
+    expect(cfpLoadingBar.status()).toBe 0
+    $httpBackend.verifyNoOutstandingRequest()
+    $timeout.flush() # loading bar is animated, so flush timeout
+
   it 'should not cache when the request is a POST', inject (cfpLoadingBar) ->
     $httpBackend.expectPOST(endpoint).respond response
     $http.post(endpoint, {message: 'post'}).then (data) ->


### PR DESCRIPTION
I've encountered that, when `$http.defaults.cache` property has been set to `true`, loading bar isn't working. To fix that issue I borrow cache choose logic from original angular $http service ([from there](https://github.com/angular/angular.js/blob/master/src/ng/http.js#L890-895)).

As you can see in new test, the interceptor now can successfully handle that case
fixes #16 
