### PR TITLE
fix(cfpLoadingBar): $animate circular dep in Angular 1.3.0+

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -157,8 +157,8 @@ angular.module('cfp.loadingBar', [])
     this.parentSelector = 'body';
     this.spinnerTemplate = '<div id="loading-bar-spinner"><div class="spinner-icon"></div></div>';
 
-    this.$get = ['$document', '$timeout', '$animate', '$rootScope', function ($document, $timeout, $animate, $rootScope) {
-
+    this.$get = ['$injector', '$document', '$timeout', '$rootScope', function ($injector, $document, $timeout, $rootScope) {
+      var $animate;
       var $parentSelector = this.parentSelector,
         loadingBarContainer = angular.element('<div id="loading-bar"><div class="bar"><div class="peg"></div></div></div>'),
         loadingBar = loadingBarContainer.find('div').eq(0),
@@ -177,6 +177,10 @@ angular.module('cfp.loadingBar', [])
        * Inserts the loading bar element into the dom, and sets it to 2%
        */
       function _start() {
+        if (!$animate) {
+          $animate = $injector.get('$animate');  
+        }
+        
         var $parent = $document.find($parentSelector);
         $timeout.cancel(completeTimeout);
 
@@ -261,6 +265,9 @@ angular.module('cfp.loadingBar', [])
       }
 
       function _complete() {
+        if (!$animate) {
+          $animate = $injector.get('$animate');  
+        }
         $rootScope.$broadcast('cfpLoadingBar:completed');
         _set(1);
 


### PR DESCRIPTION
[Uncaught Error: [$injector:cdep] Circular dependency found: $http <- $templateRequest <- $animate <- cfpLoadingBar <- $http <- $templateFactory <- $view <- $state](https://docs.angularjs.org/error/$injector/cdep?p0=$http%20%3C-%20$templateRequest%20%3C-%20$animate%20%3C-%20cfpLoadingBar%20%3C-%20$http%20%3C-%20$templateFactory%20%3C-%20$view%20%3C-%20$state)
lazy load $animate to hack around circular dependency. current fix is to use an old version of $animate 
<code>"angular-animate": "1.3.0-build.3121+sha.a4520a7",</code>
