### PR TITLE
Only append bar to the first body element

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -181,7 +181,7 @@ angular.module('cfp.loadingBar', [])
           $animate = $injector.get('$animate');
         }
 
-        var $parent = $document.find($parentSelector);
+        var $parent = $document.find($parentSelector).eq(0);
         $timeout.cancel(completeTimeout);
 
         // do not continually broadcast the started event:


### PR DESCRIPTION
In the case where one is using an svg diagram with a foreign object element which contains it's own self-contained html DOM, the progress bar was being applied to all of them. Resulting in many loading bars.
This patch restricts the selector to only find one element, which will the first.
