### PR TITLE
CSS modifications to allow appending loading bar to specific elements

### DIFF
--- a/src/loading-bar.css
+++ b/src/loading-bar.css
@@ -24,6 +24,14 @@
   opacity: 1;
 }
 
+#loading-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 2px;
+  width: 100%;
+}
+
 #loading-bar .bar {
   -webkit-transition: width 350ms;
   -moz-transition: width 350ms;
@@ -31,12 +39,10 @@
   transition: width 350ms;
 
   background: #29d;
-  position: fixed;
+  position: relative;
   z-index: 10002;
-  top: 0;
-  left: 0;
   width: 100%;
-  height: 2px;
+  height: 100%;
   border-bottom-right-radius: 1px;
   border-top-right-radius: 1px;
 }
@@ -60,7 +66,7 @@
 
 #loading-bar-spinner {
   display: block;
-  position: fixed;
+  position: absolute;
   z-index: 10002;
   top: 10px;
   left: 10px;


### PR DESCRIPTION
Related to this issue/feature request: https://github.com/chieffancypants/angular-loading-bar/issues/55

This changes are seamless if you append the loading bar to the body. But you can change the element in the config doing so:

```
app.module('myApp')
    .config(['cfpLoadingBarProvider', function (cfpLoadingBarProvider) {
        cfpLoadingBarProvider.parentSelector = '#my-selector';
    }]);
```

That jQuery selector only works if you have included the whole jQuery library, which I know is kinda against Angular's philosophy. So there's still work to do, but it's one step to getting this feature done.

If you'd like to test in the example app don't forget to add relative/absolute positioning to parent element.

BTW, thanks for this great tool!
