### PR TITLE
Introduce configurable regex to use in ignoring requests

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -99,7 +99,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
        * @returns {boolean} true if to be ignored, false otherwise
        */
       function isIgnored(config) {
-        return config.ignoreLoadingBar || (urlsToIgnore != null && urlsToIgnore.test(config.url))
+        return config.ignoreLoadingBar || (urlsToIgnore != null && urlsToIgnore.test(config.url));
       }
 
       return {

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -15,6 +15,7 @@ describe 'loadingBarInterceptor Service', ->
 
   beforeEach ->
     module 'ngAnimateMock', 'chieffancypants.loadingBar', (cfpLoadingBarProvider) ->
+      cfpLoadingBarProvider.urlsToIgnore = /.*\/to_be_ignored/
       loadingBar = cfpLoadingBarProvider
       return
 
@@ -390,6 +391,16 @@ describe 'loadingBarInterceptor Service', ->
 
     $timeout.flush()
 
+  it 'should ignore requests when endpoint matches regex for urls to be ignored', inject (cfpLoadingBar) ->
+    $httpBackend.expectGET('/api/to_be_ignored').respond response
+    $http.get('/api/to_be_ignored')
+    $httpBackend.flush()
+
+    injected = isLoadingBarInjected $document.find(cfpLoadingBar.parentSelector)
+    expect(injected).toBe false
+
+    $timeout.flush()
+
   it 'should ignore responses when ignoreLoadingBar is true (#70)', inject (cfpLoadingBar) ->
     $httpBackend.expectGET(endpoint).respond response
     $httpBackend.expectGET('/service2').respond response
@@ -406,6 +417,24 @@ describe 'loadingBarInterceptor Service', ->
 
     expect(cfpLoadingBar.status()).toBe 1
     $timeout.flush() # loading bar is animated, so flush timeout
+
+  it 'should ignore responses when endpoint matches regex for urls to be ignored', inject (cfpLoadingBar) ->
+    $httpBackend.expectGET('/api/to_be_ignored').respond response
+    $httpBackend.expectGET(endpoint).respond response
+
+    $http.get('/api/to_be_ignored')
+    $http.get(endpoint)
+
+    expect(cfpLoadingBar.status()).toBe 0
+    $httpBackend.flush(1) # flush only the ignored request
+    expect(cfpLoadingBar.status()).toBe 0
+
+    $timeout.flush()
+    $httpBackend.flush()
+
+    expect(cfpLoadingBar.status()).toBe 1
+    $timeout.flush() # loading bar is animated, so flush timeout
+
 
   it 'should ignore errors when ignoreLoadingBar is true (#70)', inject (cfpLoadingBar) ->
     $httpBackend.expectGET(endpoint).respond 400
@@ -424,6 +453,22 @@ describe 'loadingBarInterceptor Service', ->
     expect(cfpLoadingBar.status()).toBe 1
     $timeout.flush() # loading bar is animated, so flush timeout
 
+  it 'should ignore errors when endpoint matches regex for urls to be ignored', inject (cfpLoadingBar) ->
+    $httpBackend.expectGET('/api/to_be_ignored').respond 400
+    $httpBackend.expectGET(endpoint).respond 400
+
+    $http.get('/api/to_be_ignored')
+    $http.get(endpoint)
+
+    expect(cfpLoadingBar.status()).toBe 0
+    $httpBackend.flush(1) # flush only the ignored request
+    expect(cfpLoadingBar.status()).toBe 0
+
+    $timeout.flush()
+    $httpBackend.flush()
+
+    expect(cfpLoadingBar.status()).toBe 1
+    $timeout.flush() # loading bar is animated, so flush timeout
 
 
 describe 'LoadingBar only', ->


### PR DESCRIPTION
My use case was that I wanted to ignore all requests that matched a certain pattern. We have a couple of autocomplete endpoints that all end like '.../complete' which shouldn't show the loading bar. Providing configurable regex would allow you to easily and broadly apply request ignoring:

```javascript
.config(['cfpLoadingBarProvider', function(cfpLoadingBarProvider) {
    cfpLoadingBarProvider.urlsToIgnore = /.*\/complete/;
  }])
```