### PR TITLE
Adding classes alongside the IDs for additional CSS targeting

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -155,8 +155,8 @@ angular.module('cfp.loadingBar', [])
     this.latencyThreshold = 100;
     this.startSize = 0.02;
     this.parentSelector = 'body';
-    this.spinnerTemplate = '<div id="loading-bar-spinner"><div class="spinner-icon"></div></div>';
-    this.loadingBarTemplate = '<div id="loading-bar"><div class="bar"><div class="peg"></div></div></div>';
+    this.spinnerTemplate = '<div id="loading-bar-spinner" class="loading-bar-spinner"><div class="spinner-icon"></div></div>';
+    this.loadingBarTemplate = '<div id="loading-bar" class="loading-bar"><div class="bar"><div class="peg"></div></div></div>';
 
     this.$get = ['$injector', '$document', '$timeout', '$rootScope', function ($injector, $document, $timeout, $rootScope) {
       var $animate;


### PR DESCRIPTION
We try to keep our css rules as classes only -- thus hoping to add in class attributes as well for targeting.