### PR TITLE
Added support for Browserify/Webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,2 @@
-require('./src/loading-bar');
+require('./build/loading-bar');
 module.exports = 'angular-loading-bar';
-

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+require('./src/loading-bar');
+module.exports = 'angular-loading-bar';
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-loading-bar",
   "version": "0.7.1",
   "description": "An automatic loading bar for AngularJS",
-  "main": "src/loading-bar.js",
+  "main": "index.js",
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
Added `angular-loading-bar` to module exports so that after installing via npm, the package can be required in the angular module dependency list such as:

```angular.module('myApp', [require('angular-loading-bar')]);```

This is helpful for Browserify and Webpack.