### PR TITLE
Added sass support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,6 +78,17 @@ module.exports = function(grunt) {
           'build/loading-bar.js':  'src/loading-bar.js',
         }
       }
+    },
+
+    sass: {
+      build: {
+        options: {
+          outputStyle: 'expanded',
+        },
+        files: {
+          'build/loading-bar-sass.css': 'src/loading-bar.scss',
+        }
+      }
     }
   });
 
@@ -85,10 +96,12 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-sass');
   grunt.loadNpmTasks('grunt-karma');
 
   grunt.registerTask('default', ['jshint', 'karma:unit', 'karma:unit13', 'uglify', 'cssmin', 'concat:build']);
   grunt.registerTask('test', ['karma:watch']);
   grunt.registerTask('build', ['default']);
+  grunt.registerTask('styles', ['sass:build']);
 
 };

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.7.1",
   "main": [
     "build/loading-bar.js",
-    "build/loading-bar.css"
+    "build/loading-bar.css",
+    "src/loading-bar.scss"
   ],
   "ignore": [
     "**/.*",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-cssmin": "~0.6.1",
     "grunt-karma": "~0.6.2",
-    "grunt-contrib-concat": "~0.3.0"
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-sass": "~1.0.0"
   }
 }

--- a/src/loading-bar.scss
+++ b/src/loading-bar.scss
@@ -1,0 +1,126 @@
+/* Variables */
+$loading-bar-color: #29d;
+
+/* Extendables */
+/* Make clicks pass-through */
+%clicks-pass-through {
+  pointer-events: none;
+  -webkit-pointer-events: none;
+  -webkit-transition: 350ms linear all;
+  -moz-transition: 350ms linear all;
+  -o-transition: 350ms linear all;
+  transition: 350ms linear all;
+}
+
+%invisible {
+  opacity: 0;
+}
+
+%visible {
+  opacity: 1;
+}
+
+/* Main classes */
+#loading-bar {
+  @extend %clicks-pass-through;
+  & .bar {
+    -webkit-transition: width 350ms;
+    -moz-transition: width 350ms;
+    -o-transition: width 350ms;
+    transition: width 350ms;
+
+    background: $loading-bar-color;
+    position: fixed;
+    z-index: 10002;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    border-bottom-right-radius: 1px;
+    border-top-right-radius: 1px;
+  }
+
+  & .peg {
+    position: absolute;
+    width: 70px;
+    right: 0;
+    top: 0;
+    height: 2px;
+    opacity: .45;
+    -moz-box-shadow: $loading-bar-color 1px 0 6px 1px;
+    -ms-box-shadow: $loading-bar-color 1px 0 6px 1px;
+    -webkit-box-shadow: $loading-bar-color 1px 0 6px 1px;
+    box-shadow: $loading-bar-color 1px 0 6px 1px;
+    -moz-border-radius: 100%;
+    -webkit-border-radius: 100%;
+    border-radius: 100%;
+  }
+
+  &.ng-enter,
+  &.ng-leave.ng-leave-active {
+    @extend %invisible;
+  }
+
+  &.ng-enter.ng-enter-active,
+  &.ng-leave {
+    @extend %visible;
+  }
+}
+
+#loading-bar-spinner {
+  @extend %clicks-pass-through;
+
+  display: block;
+  position: fixed;
+  z-index: 10002;
+  top: 10px;
+  left: 10px;
+
+  & .spinner-icon {
+    width: 14px;
+    height: 14px;
+
+    border:  solid 2px transparent;
+    border-top-color:  $loading-bar-color;
+    border-left-color: $loading-bar-color;
+    border-radius: 50%;
+
+    -webkit-animation: loading-bar-spinner 400ms linear infinite;
+    -moz-animation:    loading-bar-spinner 400ms linear infinite;
+    -ms-animation:     loading-bar-spinner 400ms linear infinite;
+    -o-animation:      loading-bar-spinner 400ms linear infinite;
+    animation:         loading-bar-spinner 400ms linear infinite;
+  }
+
+  &.ng-enter,
+  &.ng-leave.ng-leave-active {
+    @extend %invisible;
+  }
+
+  &.ng-enter.ng-enter-active,
+  &.ng-leave {
+    @extend %visible;
+  }
+
+}
+
+@-webkit-keyframes loading-bar-spinner {
+  0%   { -webkit-transform: rotate(0deg);   transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-moz-keyframes loading-bar-spinner {
+  0%   { -moz-transform: rotate(0deg);   transform: rotate(0deg); }
+  100% { -moz-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-o-keyframes loading-bar-spinner {
+  0%   { -o-transform: rotate(0deg);   transform: rotate(0deg); }
+  100% { -o-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-ms-keyframes loading-bar-spinner {
+  0%   { -ms-transform: rotate(0deg);   transform: rotate(0deg); }
+  100% { -ms-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@keyframes loading-bar-spinner {
+  0%   { transform: rotate(0deg);   transform: rotate(0deg); }
+  100% { transform: rotate(360deg); transform: rotate(360deg); }
+}


### PR DESCRIPTION
I'm using this package along with SASS and Gulp in my project. Since SASS can't import raw CSS files I had to copy and rename original CSS file to integrate it into the project. I guess I'm not the only one who uses SASS with front end automation tools, so it would be nice to add native SASS support. It helps to integrate styles seamlessly (using includePaths option).
I also added path to new sass file under bower main files list, so it could be parsed by npm-packages like main-bower-files.
P.s: I guess dummy Gruntfile "styles" task could be changed on something more advanced.
Thank you!