### PR TITLE
Add support for parcelify css bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,6 @@
     "grunt-contrib-cssmin": "~0.12.0",
     "grunt-karma": "~0.11.0",
     "grunt-contrib-concat": "^0.5.0"
-  }
+  },
+  "style" : "build/loading-bar.css"
 }


### PR DESCRIPTION
If you include the `style` element in the `package.json` you can use `parcelify` to package the CSS.
It is similar to `browerify` just for css.

see https://github.com/rotundasoftware/parcelify

I tested it, and it workend for me.