### PR TITLE
Allow empty parentSelector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
 test/coverage
 bower_components
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 test/coverage
 bower_components
+.idea

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -194,9 +194,6 @@ angular.module('cfp.loadingBar', [])
           $animate = $injector.get('$animate');
         }
 
-        // $document.find is limited to lookups by tag name in jqLite
-        // https://docs.angularjs.org/api/ng/function/angular.element
-        var $parent = angular.element($document[0].querySelector($parentSelector)).eq(0);
         $timeout.cancel(completeTimeout);
 
         // do not continually broadcast the started event:
@@ -204,15 +201,24 @@ angular.module('cfp.loadingBar', [])
           return;
         }
 
+        var parent = $document[0].querySelector($parentSelector);
+
+        if (! parent) {
+          parent = $document[0].querySelector('body');
+        }
+
+        var $parent = angular.element(parent);
+        var $after = parent.lastChild && angular.element(parent.lastChild);
+
         $rootScope.$broadcast('cfpLoadingBar:started');
         started = true;
 
         if (includeBar) {
-          $animate.enter(loadingBarContainer, $parent, $parent[0].lastChild && angular.element($parent[0].lastChild));
+          $animate.enter(loadingBarContainer, $parent, $after);
         }
 
         if (includeSpinner) {
-          $animate.enter(spinner, $parent, $parent[0].lastChild && angular.element($parent[0].lastChild));
+          $animate.enter(spinner, $parent, loadingBarContainer);
         }
 
         _set(startSize);

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -194,7 +194,7 @@ angular.module('cfp.loadingBar', [])
           $animate = $injector.get('$animate');
         }
 
-        // $document.find is limited to lookups by name in jqLite
+        // $document.find is limited to lookups by tag name in jqLite
         // https://docs.angularjs.org/api/ng/function/angular.element
         var $parent = angular.element($document[0].querySelector($parentSelector)).eq(0);
         $timeout.cancel(completeTimeout);

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -194,7 +194,9 @@ angular.module('cfp.loadingBar', [])
           $animate = $injector.get('$animate');
         }
 
-        var $parent = $document.find($parentSelector).eq(0);
+        // $document.find is limited to lookups by name in jqLite
+        // https://docs.angularjs.org/api/ng/function/angular.element
+        var $parent = angular.element($document[0].querySelector($parentSelector)).eq(0);
         $timeout.cancel(completeTimeout);
 
         // do not continually broadcast the started event:
@@ -206,11 +208,11 @@ angular.module('cfp.loadingBar', [])
         started = true;
 
         if (includeBar) {
-          $animate.enter(loadingBarContainer, $parent, angular.element($parent[0].lastChild));
+          $animate.enter(loadingBarContainer, $parent, $parent[0].lastChild && angular.element($parent[0].lastChild));
         }
 
         if (includeSpinner) {
-          $animate.enter(spinner, $parent, angular.element($parent[0].lastChild));
+          $animate.enter(spinner, $parent, $parent[0].lastChild && angular.element($parent[0].lastChild));
         }
 
         _set(startSize);

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -201,10 +201,14 @@ angular.module('cfp.loadingBar', [])
           return;
         }
 
-        var parent = $document[0].querySelector($parentSelector);
+        var document = $document[0];
+        var parent = document.querySelector ?
+          document.querySelector($parentSelector)
+          : $document.find($parentSelector)[0]
+        ;
 
         if (! parent) {
-          parent = $document[0].querySelector('body');
+          parent = document.getElementsByTagName('body')[0];
         }
 
         var $parent = angular.element(parent);

--- a/test/loading-bar-interceptor-config.coffee
+++ b/test/loading-bar-interceptor-config.coffee
@@ -96,3 +96,19 @@ describe 'loadingBarInterceptor Service - config options', ->
       expect(children[1].id).toBe 'loading-bar-spinner'
       cfpLoadingBar.complete()
       $timeout.flush()
+
+  it 'should append the loading bar to the body if parentSelector is empty', ->
+    module 'chieffancypants.loadingBar', (cfpLoadingBarProvider) ->
+      cfpLoadingBarProvider.parentSelector = '#doesnotexist'
+      return
+    inject ($timeout, $document, cfpLoadingBar) ->
+      parent = $document[0].querySelector(cfpLoadingBar.parentSelector)
+      expect(parent).toBeFalsy;
+      body = $document[0].querySelector 'body'
+      cfpLoadingBar.start()
+      bar = angular.element(body.querySelector '#loading-bar');
+      spinner = angular.element(body.querySelector '#loading-bar-spinner');
+      expect(bar.length).toBe 1
+      expect(spinner.length).toBe 1
+      cfpLoadingBar.complete()
+      $timeout.flush()

--- a/test/loading-bar-interceptor-config.coffee
+++ b/test/loading-bar-interceptor-config.coffee
@@ -79,3 +79,20 @@ describe 'loadingBarInterceptor Service - config options', ->
       expect(cfpLoadingBar.status()).toBeGreaterThan .5
       cfpLoadingBar.complete()
       $timeout.flush()
+
+  it 'should append the loadingbar as the first child of the parent container if empty', ->
+    emptyEl = angular.element '<div id="empty"></div>'
+    angular.element(document).find('body').eq(0).append emptyEl
+
+    module 'chieffancypants.loadingBar', (cfpLoadingBarProvider) ->
+      cfpLoadingBarProvider.parentSelector = '#empty'
+      return
+    inject ($timeout, $document, cfpLoadingBar) ->
+      cfpLoadingBar.start()
+      parent = $document[0].querySelector(cfpLoadingBar.parentSelector)
+      children = parent.childNodes
+      expect(children.length).toBe 2
+      expect(children[0].id).toBe 'loading-bar'
+      expect(children[1].id).toBe 'loading-bar-spinner'
+      cfpLoadingBar.complete()
+      $timeout.flush()


### PR DESCRIPTION
This patch builds on #218, which supersedes, because it wasn't handling all the cases.

This fixes #239, angular-ui/ui-router#2260 and #179 by appending the bar to the body tag when the specified selector (if any) is not available. The check happens when `start()` is invoked, so as soon as the selector is ready it will be used, without involving `$timeout` or such things.