### PR TITLE
Define an AMD module if require.js is loaded

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -320,4 +320,16 @@ angular.module('cfp.loadingBar', [])
 
     }];     //
   });       // wtf javascript. srsly
+    /**
+     *  Support Require.JS AMD Modules
+     *  Check if define is a function then
+     *  define AMD module
+     */
+
+     if(typeof define === 'function') {
+         define([], function(){
+            return angular.module('chieffancypants.loadingBar');
+         });
+     }
+
 })();       //


### PR DESCRIPTION
This pull request solve this Issue
https://github.com/chieffancypants/angular-loading-bar/issues/246

At requireJs.config
1- i added this line to the pathes
loadingBar:'bower_components/angular-loading-bar/build/loading-bar.min',

2-and i use shim to add angular as dependency for that module
 loadingBar: {
                exports: 'loadingBar',
                deps:['angular']
            },

i have my mainAngularModule called appModule;
what i am trying to do is to add the loadingBar module as a dependency in my appModule

var loadingBar = require('loadingBar');
console.log(loadingBar);
//display undefined

    var appModule = angular.module('appModule', [
    loadingBar.name
    ]);

it throw error because loadingBar is undefined
but when i added the module name as string it works

    var appModule = angular.module('appModule', [
    'chieffancypants.loadingBar'
    ]);

but by checking if define is a function then define an AMD module will solve the problem