### PR TITLE
cleanup after bad errors

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -107,8 +107,9 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         },
 
         'response': function(response) {
+          // https://github.com/chieffancypants/angular-loading-bar/pull/50
           if (!response || !response.config) {
-            $log.error('Broken interceptor detected: Config object not supplied in response:\n https://github.com/chieffancypants/angular-loading-bar/pull/50');
+            $log.error('Broken interceptor detected: Config object not supplied in response');
             return response;
           }
 
@@ -125,8 +126,9 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         },
 
         'responseError': function(rejection) {
+          // https://github.com/chieffancypants/angular-loading-bar/pull/50
           if (!rejection || !rejection.config) {
-            $log.error('Broken interceptor detected: Config object not supplied in rejection:\n https://github.com/chieffancypants/angular-loading-bar/pull/50');
+            $log.error('Broken interceptor detected: Config object not supplied in rejection');
             return $q.reject(rejection);
           }
 

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -490,7 +490,7 @@ describe 'LoadingBar only', ->
 
 
 describe 'Interceptor tests', ->
-  provider = $http = $httpBackend = $log = $document = null
+  provider = $http = $httpBackend = $log = null
   endpoint = '/service'
   response = {message:'OK'}
 
@@ -523,8 +523,7 @@ describe 'Interceptor tests', ->
   describe 'Error response', ->
 
     beforeEach ->
-      module 'chieffancypants.loadingBar', ($httpProvider, cfpLoadingBarProvider) ->
-          loadingBar = cfpLoadingBarProvider
+      module 'chieffancypants.loadingBar', ($httpProvider) ->
           provider = $httpProvider
           provider.interceptors.push ($q) ->
             responseError: (resp) ->
@@ -536,7 +535,6 @@ describe 'Interceptor tests', ->
           $http = _$http_
           $httpBackend = _$httpBackend_
           $log = _$log_
-          $document = _$document_
 
 
     it 'should warn the user for responses with no config on the response', ->


### PR DESCRIPTION
## Issue description:
I wasn't able to figure out how to test it, but on IE9 CORS issues just error out with a console message `Error: Access is Denied` and the module never reaches `loaded` event. This fixes that.

## Issues this addresses
https://github.com/chieffancypants/angular-loading-bar/issues/258, https://github.com/chieffancypants/angular-loading-bar/issues/254, https://github.com/chieffancypants/angular-loading-bar/issues/249

## relavent prs
https://github.com/chieffancypants/angular-loading-bar/pull/50

## notes
* if there is no `response` or `response.config` that is an indicator of a bad error, we should throw in the towel and call it complete
* update error messages, log response so we can troubleshoot the issue

