### PR TITLE
Resolved issue with parentSelector when using a barren parent.

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -206,11 +206,11 @@ angular.module('cfp.loadingBar', [])
         started = true;
 
         if (includeBar) {
-          $animate.enter(loadingBarContainer, $parent, angular.element($parent[0].lastChild));
+          $animate.enter(loadingBarContainer, $parent, $parent.children().length > 0 ? $parent.children().last() : null);
         }
 
         if (includeSpinner) {
-          $animate.enter(spinner, $parent, angular.element($parent[0].lastChild));
+          $animate.enter(spinner, $parent, $parent.children().length > 0 ? $parent.children().last() : null);
         }
 
         _set(startSize);

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -204,13 +204,16 @@ angular.module('cfp.loadingBar', [])
 
         $rootScope.$broadcast('cfpLoadingBar:started');
         started = true;
+        
+        var $children = $parent.children();
 
         if (includeBar) {
-          $animate.enter(loadingBarContainer, $parent, $parent.children().length > 0 ? $parent.children().last() : null);
+          
+          $animate.enter(loadingBarContainer, $parent, $children.length > 0 ? $children[$children.length - 1] : null);
         }
 
         if (includeSpinner) {
-          $animate.enter(spinner, $parent, $parent.children().length > 0 ? $parent.children().last() : null);
+          $animate.enter(spinner, $parent, $children.length > 0 ? $children[$children.length - 1] : null);
         }
 
         _set(startSize);


### PR DESCRIPTION
I have modified the $animate.enter() associated with the bar and spinner resolving the issue related to using a childless parent.