### PR TITLE
add option to disable the $http interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ angular.module('myApp', ['angular-loading-bar'])
 ```
 
 #### Turn the $http interceptor off:
-If you would like to disable $http intercpetor globally (that is tuned on by default):
+If you would like to disable the $http interceptor globally, use the following configuration
 
 ```js
 angular.module('myApp', ['angular-loading-bar'])

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ angular.module('myApp', ['angular-loading-bar'])
   }])
 ```
 
+#### Turn the $http interceptor off:
+If you would like to disable $http intercpetor globally (that is tuned on by default):
+
+```js
+angular.module('myApp', ['angular-loading-bar'])
+  .config(['cfpLoadingBarProvider', function(cfpLoadingBarProvider) {
+    cfpLoadingBarProvider.interceptor = false;
+  }])
+```
+
 #### Customize the template:
 If you'd like to replace the default HTML template you can configure it by providing inline HTML as a string:
 

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -92,6 +92,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
       return {
         'request': function(config) {
           // Check to make sure this request hasn't already been cached and that
+          // the $http interceptor hasn't been disabled globally or
           // the requester didn't explicitly ask us to ignore this request:
           if (cfpLoadingBarProvider.interceptor && !config.ignoreLoadingBar && !isCached(config)) {
             $rootScope.$broadcast('cfpLoadingBar:loading', {url: config.url});

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -24,7 +24,7 @@ angular.module('chieffancypants.loadingBar', ['cfp.loadingBarInterceptor']);
  * Registers itself as an Angular interceptor and listens for XHR requests.
  */
 angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
-  .config(['$httpProvider', function ($httpProvider) {
+  .config(['$httpProvider', 'cfpLoadingBarProvider', function ($httpProvider, cfpLoadingBarProvider) {
 
     var interceptor = ['$q', '$cacheFactory', '$timeout', '$rootScope', '$log', 'cfpLoadingBar', function ($q, $cacheFactory, $timeout, $rootScope, $log, cfpLoadingBar) {
 
@@ -93,7 +93,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         'request': function(config) {
           // Check to make sure this request hasn't already been cached and that
           // the requester didn't explicitly ask us to ignore this request:
-          if (!config.ignoreLoadingBar && !isCached(config)) {
+          if (cfpLoadingBarProvider.interceptor && !config.ignoreLoadingBar && !isCached(config)) {
             $rootScope.$broadcast('cfpLoadingBar:loading', {url: config.url});
             if (reqsTotal === 0) {
               startTimeout = $timeout(function() {
@@ -112,7 +112,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
             return response;
           }
 
-          if (!response.config.ignoreLoadingBar && !isCached(response.config)) {
+          if (cfpLoadingBarProvider.interceptor && !response.config.ignoreLoadingBar && !isCached(response.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: response.config.url, result: response});
             if (reqsCompleted >= reqsTotal) {
@@ -130,7 +130,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
             return $q.reject(rejection);
           }
 
-          if (!rejection.config.ignoreLoadingBar && !isCached(rejection.config)) {
+          if (cfpLoadingBarProvider.interceptor && !rejection.config.ignoreLoadingBar && !isCached(rejection.config)) {
             reqsCompleted++;
             $rootScope.$broadcast('cfpLoadingBar:loaded', {url: rejection.config.url, result: rejection});
             if (reqsCompleted >= reqsTotal) {
@@ -160,6 +160,7 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
 angular.module('cfp.loadingBar', [])
   .provider('cfpLoadingBar', function() {
 
+    this.interceptor = true;
     this.autoIncrement = true;
     this.includeSpinner = true;
     this.includeBar = true;

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -552,3 +552,31 @@ describe 'Interceptor tests', ->
 
       expect($log.error.logs.length).toBe 1
       expect($log.error.logs).toContain ['Broken interceptor detected: Config object not supplied in rejection:\n https://github.com/chieffancypants/angular-loading-bar/pull/50']
+
+
+  describe 'Allow to disable interceptor', ->
+
+    beforeEach ->
+      module 'chieffancypants.loadingBar', (cfpLoadingBarProvider, $httpProvider) ->
+        provider = cfpLoadingBarProvider
+        provider.interceptor = false
+
+    it 'should not run http interceptor if disabled', inject ($http, $rootScope) ->
+      startedEventCalled = false
+      loadedEventCalled = false
+      completedEventCalled = false
+
+      $rootScope.$on 'cfpLoadingBar:started', (event) ->
+        startedEventCalled = true
+
+      $rootScope.$on 'cfpLoadingBar:loaded', (event) ->
+        loadedEventCalled = true
+
+      $rootScope.$on 'cfpLoadingBar:completed', (event) ->
+        completedEventCalled = true
+
+      $http.get('/service')
+
+      expect(startedEventCalled).toBe false
+      expect(loadedEventCalled).toBe false
+      expect(completedEventCalled).toBe false


### PR DESCRIPTION
Hi,

First of all, this library is awesome but i had to use it as stand alone loading library for switching between states so i had to add option to disable default $http interceptor. 

With this option disabled you can use this library as regular loading lib with explicitly calling `cfpLoadingBar.start()`, `cfpLoadingBar.inc()`,  `cfpLoadingBar.complete()` when needed without it to trigger automatically with `$http` promises.
