### PR TITLE
Use css3 for showing/hiding the loading bar and spinner.

### DIFF
--- a/src/loading-bar.css
+++ b/src/loading-bar.css
@@ -10,26 +10,25 @@
   transition: 350ms linear all;
 }
 
-#loading-bar.ng-enter,
-#loading-bar.ng-leave.ng-leave-active,
-#loading-bar-spinner.ng-enter,
-#loading-bar-spinner.ng-leave.ng-leave-active {
-  opacity: 0;
-}
-
-#loading-bar.ng-enter.ng-enter-active,
-#loading-bar.ng-leave,
-#loading-bar-spinner.ng-enter.ng-enter-active,
-#loading-bar-spinner.ng-leave {
+#loading-bar.active,
+#loading-bar-spinner.active {
+  visibility: visible;
   opacity: 1;
 }
 
-#loading-bar .bar {
+#loading-bar, #loading-bar-spinner {
+  visibility: hidden;
+  opacity: 0;
+}
+
+#loading-bar.active .bar {
   -webkit-transition: width 350ms;
   -moz-transition: width 350ms;
   -o-transition: width 350ms;
   transition: width 350ms;
+}
 
+#loading-bar .bar {
   background: #29d;
   position: fixed;
   z-index: 10002;


### PR DESCRIPTION
I recently had an issue with the loading bar flashing before it faded in, so I updated the bar to use css3 transitions instead of $animate for fade in/out.  This seems to work just like it did before, and it simplified the css a little.

The bar and spinner are now only inserted the first time _start is called, and shown/hidden by adding/removing the `active` class.  Unfortunately, `ngAnimate` can't quite be removed as a dependency since we still need a cleanup promise from `$animate.removeClass`, but at least it's used minimally.

I couldn't get the tests to run, however...  `npm install && grunt build` resulted in the following error:
```
INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket dQ8W-wHi5PloAH_AWF1c with id 18246745
PhantomJS 1.9.8 (Mac OS X 0.0.0) ERROR
  ReferenceError: Can't find variable: angular
  at /.../angular-loading-bar/src/loading-bar.js:17
```

Everything seems ok in the example project, though, so I'm going to start using this fork in the hopes that this will get merged eventually.