### PR TITLE
Moved position/z-index properties to parent element to fix overlap issue

### DIFF
--- a/src/loading-bar.css
+++ b/src/loading-bar.css
@@ -8,6 +8,8 @@
   -moz-transition: 350ms linear all;
   -o-transition: 350ms linear all;
   transition: 350ms linear all;
+  position: fixed;
+  z-index: 10002;
 }
 
 #loading-bar.ng-enter,
@@ -32,7 +34,6 @@
 
   background: #29d;
   position: fixed;
-  z-index: 10002;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Placed the position and z-index properties on the parent element to address the issue of the loading bar sitting beneath any fixed position item (like a navbar) that sits in the same position. The issue was outlined nicely here: https://github.com/chieffancypants/angular-loading-bar/issues/323