### PR TITLE
allow requests to be manually cancelled on broadcast from outside of l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ The loading bar broadcasts the following events over $rootScope allowing further
 
 **`cfpLoadingBar:completed`** triggered once when the all XHR requests have returned (either successfully or not)
 
+The loading bar can also be manually closed by firing an event
+
+**`cfpLoadingBar:manual-loaded`** Trigger this if you want to leave connection open, but cancel loading bar
+
 ## Credits:
 Credit goes to [rstacruz](https://github.com/rstacruz) for his excellent [nProgress](https://github.com/rstacruz/nprogress).
 

--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -88,6 +88,19 @@ angular.module('cfp.loadingBarInterceptor', ['cfp.loadingBar'])
         return cached;
       }
 
+      $rootScope.$on('cfpLoadingBar:manual-loaded', function(event, config) {
+
+        if (!config.result.config.ignoreLoadingBar && !isCached(config.result.config)) {
+          reqsCompleted++;
+          $rootScope.$broadcast('cfpLoadingBar:loaded',config);
+          if (reqsCompleted >= reqsTotal) {
+            setComplete();
+          } else {
+            cfpLoadingBar.set(reqsCompleted / reqsTotal);
+          }
+        }
+      });
+
 
       return {
         'request': function(config) {

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -200,6 +200,24 @@ describe 'loadingBarInterceptor Service', ->
     expect(cfpLoadingBar.status()).toBe 1
 
     $timeout.flush()
+    
+  it 'should count http manual loaded event as responses so the loading bar can complete', inject (cfpLoadingBar, $rootScope) ->
+    # $httpBackend.expectGET(endpoint).respond response
+    $httpBackend.expectGET(endpoint).respond 401
+    $httpBackend.expectGET(endpoint).respond 401
+    $http.get(endpoint)
+    $http.get(endpoint)
+
+    expect(cfpLoadingBar.status()).toBe 0
+    $timeout.flush()
+    $timeout.flush()
+    $httpBackend.flush(1)
+    expect(cfpLoadingBar.status()).toBe 0.5
+    
+    $rootScope.$emit('cfpLoadingBar:manual-loaded', {url: endpoint, result: { config: { cache : false}}})
+    expect(cfpLoadingBar.status()).toBe 1
+
+    $timeout.flush()
 
   it 'should insert the loadingbar into the DOM when a request is sent', inject (cfpLoadingBar) ->
     $httpBackend.expectGET(endpoint).respond response


### PR DESCRIPTION
<!--
Note that leaving sections blank will make it difficult for us understand what this PR is for and it may be closed.
-->

**Allow a request to be manualy cancelled from outside loading interceptor**

If when logged out the error responses are stashed to be completed once reloged in, these are still seen as open requests, so the loading bar is kept open, this way we can manually close the loading bar in this situation from an auth interceptor or similar

**Unit test has been added but due to the set up and assuming global installation of needed config I was unable to run without rewriting a lot of the config**

