### PR TITLE
Fix endless timeout loop

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -244,7 +244,7 @@ angular.module('cfp.loadingBar', [])
         // increment loadingbar to give the illusion that there is always
         // progress but make sure to cancel the previous timeouts so we don't
         // have multiple incs running at the same time.
-        if (autoIncrement) {
+        if (autoIncrement && status < 0.99) {
           $timeout.cancel(incTimeout);
           incTimeout = $timeout(function() {
             _inc();

--- a/test/loading-bar-interceptor.coffee
+++ b/test/loading-bar-interceptor.coffee
@@ -341,6 +341,11 @@ describe 'loadingBarInterceptor Service', ->
     $timeout.flush()
     width2 = lbar.children().css('width').slice(0, -1)
     expect(width2).toBe width
+    $timeout.verifyNoPendingTasks()
+
+    # stops timeout:
+    cfpLoadingBar.set(0.993)
+    $timeout.verifyNoPendingTasks()
 
 
     cfpLoadingBar.complete()


### PR DESCRIPTION
**What issue is this PR resolving? Alternatively, please describe the bugfix/enhancement this PR aims to provide**

_inc() does not change the status if status is larger or equal than 0.99. So no new $timeout promises need to be created if status >= 0.99.
    
This will fix some issues with protractor which waits until all $timeout promises are completed. Before new $timeout promises where created again and again and protractor timeouts occurred.

**Have you provided unit tests that either prove the bugfix or cover the enhancement?**

Test provided that no new $timeout is created after status reaches 0.99

**Related issues**
#337 