### PR TITLE
Allow to add spinner without bar

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -222,7 +222,7 @@ angular.module('cfp.loadingBar', [])
         }
 
         if (includeSpinner) {
-          $animate.enter(spinner, $parent, loadingBarContainer);
+          $animate.enter(spinner, $parent, includeBar ? loadingBarContainer : $after);
         }
 
         _set(startSize);


### PR DESCRIPTION
Hey,
I've noticed you can't actually add the spinner when bar is not included, so I provided a hotfix.