### PR TITLE
fix: clear progress bar width after animation is completed

### DIFF
--- a/src/loading-bar.js
+++ b/src/loading-bar.js
@@ -294,6 +294,7 @@ angular.module('cfp.loadingBar', [])
       function _completeAnimation() {
         status = 0;
         started = false;
+        loadingBar.css('width', 0);
       }
 
       function _complete() {


### PR DESCRIPTION
Sets bar width to 0 when animation is completed. It prevents full-width progress bar blinking after new animation call.
Steps to reproduce bug:
1. Go to demo page and click "Real Example".
2. Set debugger [Here](https://github.com/chieffancypants/angular-loading-bar/blob/master/src/loading-bar.js#L221)
`if (includeBar) {
          $animate.enter(loadingBarContainer, $parent);
        }`
3. Click  "Real Example" again and check loadingBarContainer's childNode styles. Here will be width:100%. Also you will see progress bar with full width.

Browser: Any